### PR TITLE
ci: unpin Node.js 22.x

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -14,7 +14,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [ '18.x',  '20.x', '21.x', '22.6' ]
+        node-version: [ '18.x',  '20.x', '21.x', '22.x' ]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Now that Node.js 22.8 is out, which fixes
https://github.com/nodejs/node/issues/54518, we can unpin Node.js 22 again. This commit reverts #80345a1cd11a13a7fa9e7db8230244ed56c78034.