### PR TITLE
fix: only warn for Node.js versions >= 25.x

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -25,6 +25,8 @@ jobs:
           - '22.x'
           - '23.x'
           - '24.x'
+          # Maintenance note: Update the semver expression `untestedVersionRange` in src/index.ts when adding new
+          # Node.js versions to the test matrix.
 
     steps:
       - uses: actions/checkout@v4

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,10 @@ const versionMapping = [
   // OpenTelemetry JS SDK 2.x, supports Node.js >= 18.19.0 || >= 20.6.0
   ['>=18.19.0', './2.x/init'],
 ];
-const untestedVersionRange = '>=24.0.0';
+
+// Maintenance note: This needs to be kept in sync with the version ranges in .github/workflows/verify.yaml, property
+// jobs.verify.strategy.matrix.node-version.
+const untestedVersionRange = '>=25.0.0';
 
 const prefix = 'Dash0 OpenTelemetry Distribution';
 


### PR DESCRIPTION
The CI test matrix includes Node.js 24.