### PR TITLE
chore: move package from @dash0hq/opentelemetry to @dash0/opentelemetry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ dist/
 node_modules/
 npm-debug*
 .nyc_output/
-dash0hq-opentelemetry-*.tgz
+dash0-opentelemetry-*.tgz

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@dash0hq/opentelemetry",
+  "name": "@dash0/opentelemetry",
   "version": "0.0.0-managed-by-semantic-release",
   "description": "Dash0 OpenTelemetry Wrapper for Node.js",
   "main": "dist/src/index.js",
@@ -9,7 +9,7 @@
     "verify": "npm run lint && npm test",
     "lint": "npm run eslint && npm run prettier-check",
     "eslint": "eslint eslint.config.mjs src test",
-    "prepack": "rimraf dash0hq-opentelemetry-*.tgz && npm run build",
+    "prepack": "rimraf dash0-opentelemetry-*.tgz && npm run build",
     "prettier": "prettier --write eslint.config.mjs .mocharc.js 'src/**/*.[jt]s' 'test/**/*.[jt]s' --parser typescript",
     "prettier-check": "prettier --check eslint.config.mjs 'src/**/*.[jt]s' 'test/**/*.[jt]s' --parser typescript",
     "test": "npm run test:unit && npm run test:integration",

--- a/src/1.x/init.ts
+++ b/src/1.x/init.ts
@@ -55,7 +55,7 @@ try {
 if (packageJson) {
   // Since we read the package.json from two possible relative paths, we are extra-careful to make sure we actually are
   // reading from our own package.json file, hence the name check.
-  if (packageJson.name === '@dash0hq/opentelemetry') {
+  if (packageJson.name === '@dash0/opentelemetry') {
     version = packageJson.version;
   } else {
     printDebugStderr(

--- a/src/2.x/init.ts
+++ b/src/2.x/init.ts
@@ -55,7 +55,7 @@ try {
 if (packageJson) {
   // Since we read the package.json from two possible relative paths, we are extra-careful to make sure we actually are
   // reading from our own package.json file, hence the name check.
-  if (packageJson.name === '@dash0hq/opentelemetry') {
+  if (packageJson.name === '@dash0/opentelemetry') {
     version = packageJson.version;
   } else {
     printDebugStderr(


### PR DESCRIPTION
BREAKING CHANGE: This is a breaking change for code that is using this package directly, instead of relying on the Dash0 Kubernetes operator.