### PR TITLE
Use default collector URL when env var is unset

### DIFF
--- a/src/1.x/init.ts
+++ b/src/1.x/init.ts
@@ -23,7 +23,12 @@ import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-node-1.x';
 
 import PodUidDetector from './detectors/node/opentelemetry-resource-detector-kubernetes-pod';
 import ServiceNameFallbackDetector from './detectors/node/opentelemetry-resource-detector-service-name-fallback';
-import { hasOptedIn, hasOptedOut, parseNumericEnvironmentVariableWithDefault } from '../util/environment';
+import {
+  dash0CollectorBaseUrl,
+  hasOptedIn,
+  hasOptedOut,
+  parseNumericEnvironmentVariableWithDefault,
+} from '../util/environment';
 import { kafkaJsInstrumentation } from '../util/kafkajs';
 
 const logPrefix = 'Dash0 OpenTelemetry distribution for Node.js:';
@@ -67,8 +72,7 @@ printDebugStdout('Starting NodeSDK.');
 
 let sdkShutdownHasBeenCalled = false;
 
-// Note: There is a check in index.ts that this env var is set.
-const baseUrl = process.env.DASH0_OTEL_COLLECTOR_BASE_URL;
+const baseUrl = dash0CollectorBaseUrl();
 
 const configuration: Partial<NodeSDKConfiguration> = {
   // Ignore TS2322 triggered by different import paths due to custom package aliases being used in package.json

--- a/src/2.x/init.ts
+++ b/src/2.x/init.ts
@@ -23,7 +23,12 @@ import { ConsoleSpanExporter } from '@opentelemetry/sdk-trace-node';
 
 import PodUidDetector from './detectors/node/opentelemetry-resource-detector-kubernetes-pod';
 import ServiceNameFallbackDetector from './detectors/node/opentelemetry-resource-detector-service-name-fallback';
-import { hasOptedIn, hasOptedOut, parseNumericEnvironmentVariableWithDefault } from '../util/environment';
+import {
+  dash0CollectorBaseUrl,
+  hasOptedIn,
+  hasOptedOut,
+  parseNumericEnvironmentVariableWithDefault,
+} from '../util/environment';
 import { kafkaJsInstrumentation } from '../util/kafkajs';
 
 const logPrefix = 'Dash0 OpenTelemetry distribution for Node.js:';
@@ -67,8 +72,7 @@ printDebugStdout('Starting NodeSDK.');
 
 let sdkShutdownHasBeenCalled = false;
 
-// Note: There is a check in index.ts that this env var is set.
-const baseUrl = process.env.DASH0_OTEL_COLLECTOR_BASE_URL;
+const baseUrl = dash0CollectorBaseUrl();
 
 const configuration: Partial<NodeSDKConfiguration> = {
   spanProcessors: spanProcessors(),

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,8 +62,6 @@ function init() {
 
 if (process.env.DASH0_DISABLE != null && process.env.DASH0_DISABLE.toLowerCase() === 'true') {
   logProhibitiveError(`The distribution has been disabled by setting DASH0_DISABLE=${process.env.DASH0_DISABLE}.`);
-} else if (process.env.DASH0_OTEL_COLLECTOR_BASE_URL == null) {
-  logProhibitiveError(`DASH0_OTEL_COLLECTOR_BASE_URL is not set.`);
 } else {
   init();
 }

--- a/src/util/environment.ts
+++ b/src/util/environment.ts
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: Copyright 2024 Dash0 Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+export const DEFAULT_DASH0_OTEL_COLLECTOR_BASE_URL =
+  'http://dash0-operator-opentelemetry-collector.dash0-operator-system.svc.cluster.local:4318';
+
 export function hasOptedIn(envVarName: string) {
   const raw = process.env[envVarName];
   return raw != null && raw.toLowerCase() === 'true';
@@ -21,4 +24,12 @@ export function parseNumericEnvironmentVariableWithDefault(envVarName: string, d
     return defaultValue;
   }
   return value;
+}
+
+export function dash0CollectorBaseUrl(): string {
+  const raw = process.env.DASH0_OTEL_COLLECTOR_BASE_URL;
+  if (raw == null || raw.trim() === '') {
+    return DEFAULT_DASH0_OTEL_COLLECTOR_BASE_URL;
+  }
+  return raw;
 }

--- a/src/util/environment_test.ts
+++ b/src/util/environment_test.ts
@@ -3,7 +3,13 @@
 
 import { expect } from 'chai';
 
-import { hasOptedIn, hasOptedOut, parseNumericEnvironmentVariableWithDefault } from './environment';
+import {
+  DEFAULT_DASH0_OTEL_COLLECTOR_BASE_URL,
+  dash0CollectorBaseUrl,
+  hasOptedIn,
+  hasOptedOut,
+  parseNumericEnvironmentVariableWithDefault,
+} from './environment';
 
 describe('environment variables', () => {
   const envVarsUsedInTest = [
@@ -12,6 +18,7 @@ describe('environment variables', () => {
     'DASH0_TEST_IS_SET',
     'DASH0_TEST_NOT_A_NUMBER',
     'DASH0_TEST_NUMERIC_ENV_VAR',
+    'DASH0_OTEL_COLLECTOR_BASE_URL',
   ];
   const originalValues: Map<string, string | undefined> = new Map();
 
@@ -82,6 +89,23 @@ describe('environment variables', () => {
     it('returns parsed value if env var is set and can be parsed', async () => {
       process.env.DASH0_TEST_NUMERIC_ENV_VAR = '1302';
       expect(parseNumericEnvironmentVariableWithDefault('DASH0_TEST_NUMERIC_ENV_VAR', 789)).to.equal(1302);
+    });
+  });
+
+  describe('collector base url', () => {
+    it('returns the in-cluster collector URL if env var is not set', async () => {
+      delete process.env.DASH0_OTEL_COLLECTOR_BASE_URL;
+      expect(dash0CollectorBaseUrl()).to.equal(DEFAULT_DASH0_OTEL_COLLECTOR_BASE_URL);
+    });
+
+    it('returns the in-cluster collector URL if env var is blank', async () => {
+      process.env.DASH0_OTEL_COLLECTOR_BASE_URL = '  ';
+      expect(dash0CollectorBaseUrl()).to.equal(DEFAULT_DASH0_OTEL_COLLECTOR_BASE_URL);
+    });
+
+    it('returns the configured collector URL if env var is set', async () => {
+      process.env.DASH0_OTEL_COLLECTOR_BASE_URL = 'http://collector.example.test:4318';
+      expect(dash0CollectorBaseUrl()).to.equal('http://collector.example.test:4318');
     });
   });
 });


### PR DESCRIPTION
## Summary
- make the documented in-cluster collector URL the runtime default when DASH0_OTEL_COLLECTOR_BASE_URL is missing or blank
- use the shared collector URL helper from both the OpenTelemetry SDK 1.x and 2.x initialization paths
- remove the top-level guard that disabled the distribution whenever the env var was unset
- add unit coverage for missing, blank, and custom collector URL behavior

## Why
The README documents a default collector URL of http://dash0-operator-opentelemetry-collector.dash0-operator-system.svc.cluster.local:4318, but src/index.ts currently disables the distribution entirely if DASH0_OTEL_COLLECTOR_BASE_URL is not set. That makes the documented Kubernetes/operator default unreachable unless the env var is explicitly injected.

This keeps explicit DASH0_DISABLE behavior unchanged while allowing the package to use the documented collector default.

## Verification
- npm run test:unit -- src/util/environment_test.ts
- npm run build
- npm run prettier-check -- src/index.ts src/1.x/init.ts src/2.x/init.ts src/util/environment.ts src/util/environment_test.ts
- npm run eslint -- src/index.ts src/1.x/init.ts src/2.x/init.ts src/util/environment.ts src/util/environment_test.ts
- git diff --check