### PR TITLE
ci: remove unused token secret config

### DIFF
--- a/.github/workflows/verify.yaml
+++ b/.github/workflows/verify.yaml
@@ -84,6 +84,10 @@ jobs:
         run: |
           npm run test:integration:minimum-version-check
 
+  # Note: Publishing to npm uses Trusted Publishing (OIDC) (not an npm auth token). The `id-token: write` permission
+  # above lets semantic-release/the npm CLI exchange a GitHub Actions OIDC token for a short-lived publishing token.
+  # This requires a trusted publisher to be configured for the package on npmjs.com, pointing at this repository
+  # and this workflow (npmjs.com -> package -> Settings -> Trusted Publisher).
   publish-release:
     name: Publish Release
     runs-on: ubuntu-latest
@@ -117,12 +121,4 @@ jobs:
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          # To (re-)create a suitable token, log in to https://www.npmjs.com, go to "Access Tokens" in your profile,
-          # and create a new granular access token with read and write access scope "@dash0", i.e., under
-          # "Packages and scopes", select "Only select packages and scopes", then the "dash0" scope. The user doing
-          # this neeeds to have proper access to the dash0 npm organization. Providing access to the dash0 organization
-          # (in the "Organizations" section) is not required.
-          # The token is then provided via
-          # https://github.com/dash0hq/opentelemetry-js-distribution/settings/secrets/actions as a repository secret.
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release


### PR DESCRIPTION
Since enabling the trusted publisher for this package, the legacy auth token mechanism is no longer used.